### PR TITLE
Removed minimized version from main files in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "canvg",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "homepage": "https://github.com/shprink/canvg",
     "authors": [
         "Gabe Lerner <gabelerner@gmail.com>"

--- a/bower.json
+++ b/bower.json
@@ -6,10 +6,7 @@
         "Gabe Lerner <gabelerner@gmail.com>"
     ],
     "description": "Javascript SVG parser and renderer on Canvas",
-    "main": [
-        "dist/canvg.bundle.js",
-        "dist/canvg.bundle.min.js"
-    ],
+    "main": "dist/canvg.bundle.js"
     "keywords": [
         "canvas",
         "svg",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canvg",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Javascript SVG parser and renderer on Canvas",
   "main": "none",
   "scripts": {


### PR DESCRIPTION
Tools like wiredep use the main files in bower.json to inject these files and their dependencies into a html file.
If we leave the minimized file here too this results in injection of two js files with the same content
